### PR TITLE
[Compatibility] Load correct configuration based on Spacemacs version

### DIFF
--- a/README.org
+++ b/README.org
@@ -16,10 +16,34 @@ Then, clone the layer into your =~/.emacs.d/private= directory:
 git clone git@github.com:Ruin0x11/lsp-intellij-spacemacs.git ~/.emacs.d/private/lsp-intellij
 #+END_SRC
 
-Finally, enable it (along with some extra layers for more features) in your =~/.spacemacs=:
+How you enable this layer depends on your Spacemacs version, which you can find with =M-: spacemacs-version=.
+
+** 0.200.*
+Add the following layers to your =dotspacemacs-configuration-layers= in =~/.spacemacs=:
+
+#+begin_src emacs-lisp
+  auto-completion syntax-checking lsp-intellij
+#+end_src
+
+With no other layers enabled, this will look like:
 
 #+begin_src emacs-lisp
   (setq-default dotspacemacs-configuration-layers '(auto-completion syntax-checking lsp-intellij))
 #+end_src
+
+** 0.300.*
+Add the following layers to your =dotspacemacs-configuration-layers= in =~/.spacemacs=:
+
+#+begin_src emacs-lisp
+  auto-completion syntax-checking lsp lsp-intellij
+#+end_src
+
+With no other layers enabled, this will look like:
+
+#+begin_src emacs-lisp
+  (setq-default dotspacemacs-configuration-layers '(auto-completion syntax-checking lsp lsp-intellij))
+#+end_src
+
+----------
 
 Please see the [[https://www.github.com/Ruin0x11/lsp-intellij][lsp-intellij]] repo for more information.

--- a/config.el
+++ b/config.el
@@ -1,17 +1,25 @@
-;;; packages.el --- lsp-intellij layer packages file for Spacemacs.
+;;; config.el --- lsp-intellij layer packages file for Spacemacs.
 ;;
-;; Copyright (c) 2018 Ian Pickering
+;; Copyright (c) 2018 Richard Jones
 ;;
-;; Author:  <ipickering2@gmail.com>
+;; Author:  <joneseh25@gmail.com>
 ;; URL: https://github.com/syl20bnr/spacemacs
 ;;
 ;; This file is not part of GNU Emacs.
 ;;
-;;; License: GPLv3
+;;; License: MIT
 
 ;;; Code:
 
-(spacemacs|defvar-company-backends java-mode)
-(spacemacs|defvar-company-backends kotlin-mode)
+(if (version< spacemacs-version "0.200.6")
+    (setq spacemacs//intellij-lsp-version-dir-name "spacemacs-0.200")
+  (setq spacemacs//intellij-lsp-version-dir-name "spacemacs-0.300"))
+
+(setq spacemacs//intellij-lsp-version-dir-fullpath
+      (expand-file-name spacemacs//intellij-lsp-version-dir-name
+                        (file-name-directory (or load-file-name buffer-file-name))))
+
+;; Load the relevant `config.el` based on Spacemacs version
+(load (expand-file-name "config" spacemacs//intellij-lsp-version-dir-fullpath) t)
 
 ;;; config.el ends here

--- a/config.el
+++ b/config.el
@@ -11,7 +11,7 @@
 
 ;;; Code:
 
-(if (version< spacemacs-version "0.200.6")
+(if (version< spacemacs-version "0.300")
     (setq spacemacs//intellij-lsp-version-dir-name "spacemacs-0.200")
   (setq spacemacs//intellij-lsp-version-dir-name "spacemacs-0.300"))
 

--- a/funcs.el
+++ b/funcs.el
@@ -1,4 +1,4 @@
-;;; packages.el --- lsp-intellij layer packages file for Spacemacs.
+;;; funcs.el --- lsp-intellij layer packages file for Spacemacs.
 ;;
 ;; Copyright (c) 2018 Richard Jones
 ;;
@@ -19,7 +19,7 @@
       (expand-file-name spacemacs//intellij-lsp-version-dir-name
                         (file-name-directory (or load-file-name buffer-file-name))))
 
-;; Load the relevant `packages.el` based on Spacemacs version
-(load (expand-file-name "packages" spacemacs//intellij-lsp-version-dir-fullpath) t)
+;; Load the relevant `funcs.el` based on Spacemacs version
+(load (expand-file-name "funcs" spacemacs//intellij-lsp-version-dir-fullpath) t)
 
-;;; packages.el ends here
+;;; funcs.el ends here

--- a/funcs.el
+++ b/funcs.el
@@ -11,7 +11,7 @@
 
 ;;; Code:
 
-(if (version< spacemacs-version "0.200.6")
+(if (version< spacemacs-version "0.300")
     (setq spacemacs//intellij-lsp-version-dir-name "spacemacs-0.200")
   (setq spacemacs//intellij-lsp-version-dir-name "spacemacs-0.300"))
 

--- a/packages.el
+++ b/packages.el
@@ -11,7 +11,7 @@
 
 ;;; Code:
 
-(if (version< spacemacs-version "0.200.6")
+(if (version< spacemacs-version "0.300")
     (setq spacemacs//intellij-lsp-version-dir-name "spacemacs-0.200")
   (setq spacemacs//intellij-lsp-version-dir-name "spacemacs-0.300"))
 

--- a/spacemacs-0.200/config.el
+++ b/spacemacs-0.200/config.el
@@ -1,0 +1,17 @@
+;;; packages.el --- lsp-intellij layer packages file for Spacemacs.
+;;
+;; Copyright (c) 2018 Ian Pickering
+;;
+;; Author:  <ipickering2@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;;; Code:
+
+(spacemacs|defvar-company-backends java-mode)
+(spacemacs|defvar-company-backends kotlin-mode)
+
+;;; config.el ends here

--- a/spacemacs-0.200/funcs.el
+++ b/spacemacs-0.200/funcs.el
@@ -1,0 +1,36 @@
+;;; funcs.el --- lsp-intellij layer packages file for Spacemacs.
+;;
+;; Copyright (c) 2018 Richard Jones
+;;
+;; Author:  <richajn@amazon.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: MIT
+
+;;; Code:
+
+
+(defun spacemacs//lsp-intellij-setup-leader-keys (mode)
+  (spacemacs/set-leader-keys-for-major-mode mode
+    ;; run
+    "," 'lsp-intellij-run-at-point
+    ;; configuration
+    "cr" 'lsp-intellij-open-run-configurations
+    ;; goto
+    "gg" 'xref-find-definitions
+    "gi" 'lsp-intellij-find-implementations
+    "gr" 'xref-find-references
+    ;; help/doc
+    "hs" 'xref-find-apropos
+    ;; project
+    "pb" 'lsp-intellij-build-project
+    "pr" 'lsp-intellij-run-project
+    "ps" 'lsp-intellij-open-project-structure
+    ;; refactor
+    "rf" 'lsp-format-buffer
+    ;; IDEA
+    "It" 'lsp-intellij-toggle-frame-visibility))
+
+;;; funcs.el ends here

--- a/spacemacs-0.200/packages.el
+++ b/spacemacs-0.200/packages.el
@@ -1,0 +1,102 @@
+;;; packages.el --- lsp-intellij layer packages file for Spacemacs.
+;;
+;; Copyright (c) 2018 Ian Pickering
+;;
+;; Author:  <ipickering2@gmail.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: GPLv3
+
+;;; Code:
+
+(defconst lsp-intellij-packages
+  '(
+    lsp-mode
+    kotlin-mode
+    flycheck
+    (lsp-ui :toggle (configuration-layer/package-usedp 'flycheck))
+    company
+    (company-lsp :toggle (configuration-layer/package-usedp 'company))
+    (lsp-intellij :location (recipe :fetcher github :repo "Ruin0x11/lsp-intellij"))
+    ))
+
+(defun lsp-intellij/init-lsp-mode ()
+  (use-package lsp-mode))
+
+(defun lsp-intellij/init-kotlin-mode ()
+  (use-package kotlin-mode))
+
+(defun lsp-intellij/init-lsp-ui ()
+  (use-package lsp-ui))
+
+(defun lsp-intellij/init-company-lsp ()
+  (use-package company-lsp)
+
+  (setq company-lsp-enable-snippet t
+        company-lsp-cache-candidates t)
+  (push 'company-lsp company-backends))
+
+(defun lsp-intellij/init-lsp-intellij ()
+  (with-eval-after-load 'lsp-mode
+    (use-package lsp-intellij
+      :config
+      (progn
+        ;; key bindings
+        (dolist (prefix '(
+                          ("mc" . "configuration")
+                          ("mg" . "goto")
+                          ("mh" . "help/doc")
+                          ("mp" . "project")
+                          ("mr" . "refactor")
+                          ("mI" . "IDEA")
+                          ))
+          (spacemacs/declare-prefix-for-mode
+            'java-mode (car prefix) (cdr prefix)))
+        (spacemacs/set-leader-keys-for-major-mode 'java-mode
+          ;; run
+          "," 'lsp-intellij-run-at-point
+          ;; configuration
+          "cr" 'lsp-intellij-open-run-configurations
+          ;; goto
+          "gg" 'xref-find-definitions
+          "gi" 'lsp-intellij-find-implementations
+          "gr" 'xref-find-references
+          ;; help/doc
+          "hs" 'xref-find-apropos
+          ;; project
+          "pb" 'lsp-intellij-build-project
+          "pr" 'lsp-intellij-run-project
+          "ps" 'lsp-intellij-open-project-structure
+          ;; refactor
+          "rf" 'lsp-format-buffer
+          ;; IDEA
+          "It" 'lsp-intellij-toggle-frame-visibility)
+        (evil-define-key 'insert java-mode-map
+          (kbd ".") 'spacemacs/java-lsp-completing-dot
+          (kbd ":") 'spacemacs/java-lsp-completing-double-colon
+          (kbd "M-.") 'xref-find-definitions
+          (kbd "M-,") 'pop-tag-mark))
+
+      (add-hook 'java-mode-hook #'lsp-intellij-enable)
+      (add-hook 'kotlin-mode-hook #'lsp-intellij-enable))))
+
+(defun lsp-intellij/post-init-lsp-intellij ()
+  (add-hook 'java-mode-hook #'lsp-intellij-enable)
+  (add-hook 'kotlin-mode-hook #'lsp-intellij-enable))
+
+(defun lsp-intellij/post-init-company ()
+  (spacemacs|add-company-hook java-mode)
+  (spacemacs|add-company-hook kotlin-mode)
+  (push 'company-lsp company-backends-java-mode)
+  (push 'company-lsp company-backends-kotlin-mode))
+
+(defun lsp-intellij/post-init-flycheck ()
+  (add-hook 'java-mode-hook 'flycheck-mode)
+  (add-hook 'kotlin-mode-hook 'flycheck-mode))
+
+(defun lsp-intellij/post-init-lsp-ui ()
+  (add-hook 'lsp-after-open-hook 'lsp-ui-mode))
+
+;;; packages.el ends here

--- a/spacemacs-0.200/packages.el
+++ b/spacemacs-0.200/packages.el
@@ -52,28 +52,19 @@
                           ("mr" . "refactor")
                           ("mI" . "IDEA")
                           ))
-          (spacemacs/declare-prefix-for-mode
-            'java-mode (car prefix) (cdr prefix)))
-        (spacemacs/set-leader-keys-for-major-mode 'java-mode
-          ;; run
-          "," 'lsp-intellij-run-at-point
-          ;; configuration
-          "cr" 'lsp-intellij-open-run-configurations
-          ;; goto
-          "gg" 'xref-find-definitions
-          "gi" 'lsp-intellij-find-implementations
-          "gr" 'xref-find-references
-          ;; help/doc
-          "hs" 'xref-find-apropos
-          ;; project
-          "pb" 'lsp-intellij-build-project
-          "pr" 'lsp-intellij-run-project
-          "ps" 'lsp-intellij-open-project-structure
-          ;; refactor
-          "rf" 'lsp-format-buffer
-          ;; IDEA
-          "It" 'lsp-intellij-toggle-frame-visibility)
+          (progn
+            (spacemacs/declare-prefix-for-mode
+              'java-mode (car prefix) (cdr prefix))
+            (spacemacs/declare-prefix-for-mode
+              'kotlin-mode (car prefix) (cdr prefix))))
+        (spacemacs//lsp-intellij-setup-leader-keys 'java-mode)
+        (spacemacs//lsp-intellij-setup-leader-keys 'kotlin-mode)
         (evil-define-key 'insert java-mode-map
+          (kbd ".") 'spacemacs/java-lsp-completing-dot
+          (kbd ":") 'spacemacs/java-lsp-completing-double-colon
+          (kbd "M-.") 'xref-find-definitions
+          (kbd "M-,") 'pop-tag-mark)
+        (evil-define-key 'insert kotlin-mode-map
           (kbd ".") 'spacemacs/java-lsp-completing-dot
           (kbd ":") 'spacemacs/java-lsp-completing-double-colon
           (kbd "M-.") 'xref-find-definitions

--- a/spacemacs-0.300/funcs.el
+++ b/spacemacs-0.300/funcs.el
@@ -25,6 +25,26 @@
   (spacemacs//init-company-kotlin-mode)
   (company-mode))
 
+(defun spacemacs//lsp-intellij-setup-leader-keys (mode)
+  (spacemacs/set-leader-keys-for-major-mode mode
+    ;; run
+    "," 'lsp-intellij-run-at-point
+    ;; configuration
+    "cr" 'lsp-intellij-open-run-configurations
+    ;; goto
+    "gg" 'xref-find-definitions
+    "gi" 'lsp-intellij-find-implementations
+    "gr" 'xref-find-references
+    ;; help/doc
+    "hs" 'xref-find-apropos
+    ;; project
+    "pb" 'lsp-intellij-build-project
+    "pr" 'lsp-intellij-run-project
+    "ps" 'lsp-intellij-open-project-structure
+    ;; refactor
+    "rf" 'lsp-format-buffer
+    ;; IDEA
+    "It" 'lsp-intellij-toggle-frame-visibility))
 
 ;; The following is adapted from Spacemacs' Eclim completion functions:
 ;;  https://github.com/syl20bnr/spacemacs/blob/3731d0d/layers/%2Blang/java/funcs.el

--- a/spacemacs-0.300/funcs.el
+++ b/spacemacs-0.300/funcs.el
@@ -1,0 +1,52 @@
+;;; funcs.el --- lsp-intellij layer packages file for Spacemacs.
+;;
+;; Copyright (c) 2018 Richard Jones
+;;
+;; Author:  <richajn@amazon.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: MIT
+
+;;; Code:
+
+(defun spacemacs//lsp-intellij-setup-company ()
+  (spacemacs|add-company-backends :backends company-lsp
+                                  :modes java-mode kotlin-mode
+                                  :variables company-lsp-enable-snippet t
+                                  company-transformers nil
+                                  company-lsp-async t
+                                  company-idle-delay 0.5
+                                  company-minimum-prefix-length 1
+                                  company-lsp-cache-candidates t
+                                  :hooks nil)
+  (spacemacs//init-company-java-mode)
+  (spacemacs//init-company-kotlin-mode)
+  (company-mode))
+
+
+;; The following is adapted from Spacemacs' Eclim completion functions:
+;;  https://github.com/syl20bnr/spacemacs/blob/3731d0d/layers/%2Blang/java/funcs.el
+(defun spacemacs//java-lsp-delete-horizontal-space ()
+  (when (s-matches? (rx (+ (not space)))
+                    (buffer-substring (line-beginning-position) (point)))
+    (delete-horizontal-space t)))
+
+(defun spacemacs/java-lsp-completing-dot ()
+  "Insert a period and show company completions."
+  (interactive "*")
+  (spacemacs//java-lsp-delete-horizontal-space)
+  (insert ".")
+  (company-lsp 'interactive))
+
+(defun spacemacs/java-lsp-completing-double-colon ()
+  "Insert double colon and show company completions."
+  (interactive "*")
+  (spacemacs//java-lsp-delete-horizontal-space)
+  (insert ":")
+  (let ((curr (point)))
+    (when (s-matches? (buffer-substring (- curr 2) (- curr 1)) ":")
+      (company-lsp 'interactive))))
+
+;;; funcs.el ends here

--- a/spacemacs-0.300/packages.el
+++ b/spacemacs-0.300/packages.el
@@ -1,0 +1,70 @@
+;;; packages.el --- lsp-intellij layer packages file for Spacemacs.
+;;
+;; Copyright (c) 2018 Richard Jones
+;;
+;; Author:  <richajn@amazon.com>
+;; URL: https://github.com/syl20bnr/spacemacs
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; License: MIT
+
+;;; Code:
+
+(defconst lsp-intellij-packages
+  '(company
+    flycheck
+    (lsp-intellij :location (recipe :fetcher github :repo "Ruin0x11/lsp-intellij"))))
+
+(defun lsp-intellij/post-init-company ()
+  (add-hook 'java-mode-local-vars-hook #'spacemacs//lsp-intellij-setup-company))
+
+(defun lsp-intellij/post-init-flycheck ()
+  (add-hook 'java-mode-hook 'flycheck-mode)
+  (add-hook 'kotlin-mode-hook 'flycheck-mode))
+
+(defun lsp-intellij/init-lsp-intellij ()
+  (with-eval-after-load 'lsp-mode
+    (use-package lsp-intellij
+      :config
+      (progn
+        ;; key bindings
+        (dolist (prefix '(
+                          ("mc" . "configuration")
+                          ("mg" . "goto")
+                          ("mh" . "help/doc")
+                          ("mp" . "project")
+                          ("mr" . "refactor")
+                          ("mI" . "IDEA")
+                          ))
+          (spacemacs/declare-prefix-for-mode
+            'java-mode (car prefix) (cdr prefix)))
+        (spacemacs/set-leader-keys-for-major-mode 'java-mode
+          ;; run
+          "," 'lsp-intellij-run-at-point
+          ;; configuration
+          "cr" 'lsp-intellij-open-run-configurations
+          ;; goto
+          "gg" 'xref-find-definitions
+          "gi" 'lsp-intellij-find-implementations
+          "gr" 'xref-find-references
+          ;; help/doc
+          "hs" 'xref-find-apropos
+          ;; project
+          "pb" 'lsp-intellij-build-project
+          "pr" 'lsp-intellij-run-project
+          "ps" 'lsp-intellij-open-project-structure
+          ;; refactor
+          "rf" 'lsp-format-buffer
+          ;; IDEA
+          "It" 'lsp-intellij-toggle-frame-visibility)
+        (evil-define-key 'insert java-mode-map
+          (kbd ".") 'spacemacs/java-lsp-completing-dot
+          (kbd ":") 'spacemacs/java-lsp-completing-double-colon
+          (kbd "M-.") 'xref-find-definitions
+          (kbd "M-,") 'pop-tag-mark))
+
+      (add-hook 'java-mode-hook #'lsp-intellij-enable)
+      (add-hook 'kotlin-mode-hook #'lsp-intellij-enable))))
+
+;;; packages.el ends here

--- a/spacemacs-0.300/packages.el
+++ b/spacemacs-0.300/packages.el
@@ -37,28 +37,19 @@
                           ("mr" . "refactor")
                           ("mI" . "IDEA")
                           ))
-          (spacemacs/declare-prefix-for-mode
-            'java-mode (car prefix) (cdr prefix)))
-        (spacemacs/set-leader-keys-for-major-mode 'java-mode
-          ;; run
-          "," 'lsp-intellij-run-at-point
-          ;; configuration
-          "cr" 'lsp-intellij-open-run-configurations
-          ;; goto
-          "gg" 'xref-find-definitions
-          "gi" 'lsp-intellij-find-implementations
-          "gr" 'xref-find-references
-          ;; help/doc
-          "hs" 'xref-find-apropos
-          ;; project
-          "pb" 'lsp-intellij-build-project
-          "pr" 'lsp-intellij-run-project
-          "ps" 'lsp-intellij-open-project-structure
-          ;; refactor
-          "rf" 'lsp-format-buffer
-          ;; IDEA
-          "It" 'lsp-intellij-toggle-frame-visibility)
+          (progn
+            (spacemacs/declare-prefix-for-mode
+              'java-mode (car prefix) (cdr prefix))
+            (spacemacs/declare-prefix-for-mode
+              'kotlin-mode (car prefix) (cdr prefix))))
+        (spacemacs//lsp-intellij-setup-leader-keys 'java-mode)
+        (spacemacs//lsp-intellij-setup-leader-keys 'kotlin-mode)
         (evil-define-key 'insert java-mode-map
+          (kbd ".") 'spacemacs/java-lsp-completing-dot
+          (kbd ":") 'spacemacs/java-lsp-completing-double-colon
+          (kbd "M-.") 'xref-find-definitions
+          (kbd "M-,") 'pop-tag-mark)
+        (evil-define-key 'insert kotlin-mode-map
           (kbd ".") 'spacemacs/java-lsp-completing-dot
           (kbd ":") 'spacemacs/java-lsp-completing-double-colon
           (kbd "M-.") 'xref-find-definitions


### PR DESCRIPTION
* Move spacemacs/master-compatible config to `spacemacs-0.200` directory;
* Introduce spacemacs/develop-compatible config in `spacemacs-0.300` directory;
* Add Spacemacs-style keybindings to both;
* Update installation instructions.