### PR TITLE
move some funcs to shares space

### DIFF
--- a/funcs.el
+++ b/funcs.el
@@ -11,6 +11,31 @@
 
 ;;; Code:
 
+;; shared functions
+
+;; The following is adapted from Spacemacs' Eclim completion functions:
+;;  https://github.com/syl20bnr/spacemacs/blob/3731d0d/layers/%2Blang/java/funcs.el
+(defun spacemacs//java-lsp-delete-horizontal-space ()
+  (when (s-matches? (rx (+ (not space)))
+                    (buffer-substring (line-beginning-position) (point)))
+    (delete-horizontal-space t)))
+
+(defun spacemacs/java-lsp-completing-dot ()
+  "Insert a period and show company completions."
+  (interactive "*")
+  (spacemacs//java-lsp-delete-horizontal-space)
+  (insert ".")
+  (company-lsp 'interactive))
+
+(defun spacemacs/java-lsp-completing-double-colon ()
+  "Insert double colon and show company completions."
+  (interactive "*")
+  (spacemacs//java-lsp-delete-horizontal-space)
+  (insert ":")
+  (let ((curr (point)))
+    (when (s-matches? (buffer-substring (- curr 2) (- curr 1)) ":")
+      (company-lsp 'interactive))))
+
 (if (version< spacemacs-version "0.300")
     (setq spacemacs//intellij-lsp-version-dir-name "spacemacs-0.200")
   (setq spacemacs//intellij-lsp-version-dir-name "spacemacs-0.300"))

--- a/spacemacs-0.300/funcs.el
+++ b/spacemacs-0.300/funcs.el
@@ -47,27 +47,4 @@
     ;; IDEA
     "It" 'lsp-intellij-toggle-frame-visibility))
 
-;; The following is adapted from Spacemacs' Eclim completion functions:
-;;  https://github.com/syl20bnr/spacemacs/blob/3731d0d/layers/%2Blang/java/funcs.el
-(defun spacemacs//java-lsp-delete-horizontal-space ()
-  (when (s-matches? (rx (+ (not space)))
-                    (buffer-substring (line-beginning-position) (point)))
-    (delete-horizontal-space t)))
-
-(defun spacemacs/java-lsp-completing-dot ()
-  "Insert a period and show company completions."
-  (interactive "*")
-  (spacemacs//java-lsp-delete-horizontal-space)
-  (insert ".")
-  (company-lsp 'interactive))
-
-(defun spacemacs/java-lsp-completing-double-colon ()
-  "Insert double colon and show company completions."
-  (interactive "*")
-  (spacemacs//java-lsp-delete-horizontal-space)
-  (insert ":")
-  (let ((curr (point)))
-    (when (s-matches? (buffer-substring (- curr 2) (- curr 1)) ":")
-      (company-lsp 'interactive))))
-
 ;;; funcs.el ends here


### PR DESCRIPTION
While trying this layer on spacemacs 0.200.x, it was missing these functions. This is a naive attempt and if you believe this needs to be duplicated instead of what is proposed here, I would be willing to make the modifications. I tried both ways (duplicating and moving as in this PR) and both worked. 
